### PR TITLE
Added "Hacker News sidebar" to cool apps

### DIFF
--- a/app/views/pages/cool_apps.html.haml
+++ b/app/views/pages/cool_apps.html.haml
@@ -11,6 +11,7 @@
 %h3 Chrome Extensions
 %ul
   %li <a href="https://chrome.google.com/webstore/detail/hacker-news-discussion/iggcipafbcjfofibfhhelnipahhepmkd">Hacker News discussion</a>, a Chrome extension linking to comments on Hacker News for the current page.
+  %li <a href="https://chrome.google.com/webstore/detail/hacker-news-sidebar/ngljhffenbmdjobakjplnlbfkeabbpma">Hacker News sidebar</a>, a Chrome extension that displays comments for the current page in a pullout sidebar.
   
 
 %h3 iOS Apps


### PR DESCRIPTION
I've updated my Chrome Extension, published as [Hacker News sidebar](https://chrome.google.com/webstore/detail/hacker-news-sidebar/ngljhffenbmdjobakjplnlbfkeabbpma) on the Chrome Web Store, to use your API instead of hnsearch's.  Would love if you could add me to your list of cool apps.
