### PR TITLE
add Firefox add-on Hacker News Reader

### DIFF
--- a/app/views/pages/cool_apps.html.haml
+++ b/app/views/pages/cool_apps.html.haml
@@ -15,6 +15,10 @@
   %li <a href="https://chrome.google.com/webstore/detail/hacker-news-sidebar/ngljhffenbmdjobakjplnlbfkeabbpma">Hacker News sidebar</a>, a Chrome extension that displays comments for the current page in a pullout sidebar.
   
 
+%h3 Firefox Extensions
+%ul
+  %li <a href="https://addons.mozilla.org/en-US/firefox/addon/hacker-news-reader/">Hacker News Reader</a>, a Mozilla Firefox browser add-on that has a radically new interface which combines visual density with a clean design.
+
 %h3 iOS Apps
 %ul
   %li <a href="https://itunes.apple.com/app/hacker-news-yc/id713733435?mt=8">Hacker News (YC) for Mobile/Tablet</a>


### PR DESCRIPTION
I've written a Firefox add-on [Hacker News Reader](https://addons.mozilla.org/en-US/firefox/addon/hacker-news-reader/) that makes extensive use of the Algolia HN Search API. I would appreciate it if you could add this add-on to your list of [cool apps](https://hn.algolia.io/cool_apps). The code is in my [Github repo](https://github.com/pragmatictester/hnreader).
