### PR TITLE
Use 'pollopt' for poll options, not 'pollop'

### DIFF
--- a/app/views/pages/api.html.haml
+++ b/app/views/pages/api.html.haml
@@ -103,7 +103,7 @@
       %li <code>story</code>
       %li <code>comment</code>
       %li <code>poll</code>
-      %li <code>pollop</code>
+      %li <code>pollopt</code>
       %li <code>show_hn</code>
       %li <code>ask_hn</code>
       %li <code>author_:USERNAME</code>


### PR DESCRIPTION
The API docs refer to the "pollop" tag while it actually should be "pollopt."
