### PR TITLE
Add a link to hnrss.org

### DIFF
--- a/app/views/pages/cool_apps.html.haml
+++ b/app/views/pages/cool_apps.html.haml
@@ -8,6 +8,7 @@
   %li <a href="http://hn.premii.com">hn.premii.com</a> - Mobile web app
   %li <a href="http://www.ryan-williams.net/hacker-news-hiring-trends/">Hacker News Tech Hiring Trends </a> - Monthly update of what's popular in programming languages, development frameworks and technologies as posted in "whoishiring" threads.
   %li <a href="http://webmakers.io">webmakers.io</a> - An aggregator by and for makers of today's Web
+  %li <a href="http://hnrss.org">hnrss.org</a> - Custom, realtime Hacker News RSS feeds
 
 
 %h3 Chrome Extensions


### PR DESCRIPTION
[hnrss.org](http://hnrss.org) is a project of mine that uses the Algolia API to produce custom RSS feeds for Hacker News.

If you don't mind, I'd love to have it linked on the cool apps page to spread the word.

Thanks!
