### PR TITLE
Update API description: mention limits on returned values

### DIFF
--- a/app/views/pages/api.html.haml
+++ b/app/views/pages/api.html.haml
@@ -120,6 +120,8 @@
 
 %p Tags are ANDed by default, can be ORed if between parenthesis. For example <code>author_pg,(story,poll)</code> filters on <code>author=pg AND (type=story OR type=poll)</code>.
 
+%p By default a limited number of results are returned in each page, so a given query may be broken over dozens of pages. The number of results and page number are available as the variables <code>nbPages</code> and <code>hitsPerPage</code> respectively; they can be specified as arguments in requests, allowing for more results to be requested or iteration over the available pages eg appending to the search URL parameters like <code>&page=2</code> or <code>hitsPerPage=50</code>.
+
 %p The complete list of search parameters is available in Algolia <a href="https://www.algolia.com/doc/rest_api#QueryIndex">Search API documentation</a>.
 
 %h5 Examples


### PR DESCRIPTION
While trying to export my submission metadata, I was perplexed that the request seemed to be succeeding but returning a very limited selection.
This was not covered under the rate-limiting section and it did not occur to me to go digging through the full API docs, especially since the writing of the page implies no such limits (eg. "_All_ stories matching foo" / "_All_ comments matching bar").
I think this is an issue for almost everyone doing nontrivial work with the API and so worth mentioning up front.
