### PR TITLE
feat(clickAnalytics): update insights lib

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,7 +26,7 @@
         a.async = 1;
         a.src = g;
         m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://cdn.jsdelivr.net/npm/alg-insights@0.0.3/dist/alg-insights.js', 'aa')
+      })(window, document, 'script', 'https://cdn.jsdelivr.net/npm/search-insights@0.0.14/dist/search-insights.min.js', 'aa')
       aa('init', {
         apiKey: '08240194d5ef567a9f14e0f066bace0c',
         applicationID: 'UJ5WYC0L7X'


### PR DESCRIPTION
Update click analytics library to the public and most up to date version.
This will change the targeted endpoint from the will-be-removed `h-beta.x-alg.net` to `insights.algolia.io`.

Tested on localhost and checked that request where now received on the new domain.

Before/After
![screen shot 2018-04-06 at 4 59 45 pm](https://user-images.githubusercontent.com/22078683/38428479-1c6452e8-39bc-11e8-8e0b-af6df2c4e640.png)
