### PR TITLE
Add HN Mail

### DIFF
--- a/app/assets/templates/cool_apps.html.haml
+++ b/app/assets/templates/cool_apps.html.haml
@@ -33,3 +33,7 @@
     %li <a href="https://play.google.com/store/apps/details?id=com.leavjenn.hews"> Hews for Hacker News</a>
     %li <a href="https://play.google.com/store/apps/details?id=io.github.hidroh.materialistic">Materialistic - Hacker News</a>
     %li <a href="https://play.google.com/store/apps/details?id=au.com.timmutton.yarn"> Yarn for Hacker News</a>
+
+  %h3 Newsletters
+  %ul
+    %li <a href="https://hnmail.io">HN Mail</a> - A customizable weekly newsletter service for Hacker News based on topics.


### PR DESCRIPTION
HN Mail is a weekly newsletter service that delivers Hacker News stories based on user's interested topics. As it doesn't belong to any of the existing categories which are based on platforms, so I added a new section called `Newsletters`. Let me know if this would work out.