### PR TITLE
[feature] - add navigator connection data

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -246,6 +246,13 @@ window.trackResource = function(query){
       domain: lastAlgoliaRequest.name.match(/(.*)\:\/\/(.*?)\//)[2]
     }
 
+    if (navigator.connection) {
+      data.connectionType = navigator.connection.effectiveType;
+      data.downLink = navigator.connection.downLink;
+      data.downlinkMax = navigator.connection.downlinkMax;
+      data.type = navigator.connection.type;
+    }
+
     var url = "https://telemetry.algolia.com/dev/v1/measure"
 
     if(supportsNavigator){

--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -247,7 +247,7 @@ window.trackResource = function(query){
     }
 
     if (navigator.connection) {
-      data.connectionType = navigator.connection.effectiveType;
+      data.effectiveType = navigator.connection.effectiveType;
       data.downLink = navigator.connection.downLink;
       data.downlinkMax = navigator.connection.downlinkMax;
       data.type = navigator.connection.type;


### PR DESCRIPTION
Implements tracking of actual connection data so we can have a better understanding of the conditions that the requests were performed under. Respects the naming spec defined in https://wicg.github.io/netinfo/