### PR TITLE
fix(style): header avoid scroll

### DIFF
--- a/app/assets/stylesheets/themes/default.css.sass
+++ b/app/assets/stylesheets/themes/default.css.sass
@@ -93,7 +93,6 @@ html, body
     line-height: $titleHeight
     top: $headerHeight
     h1
-      width: 100%
       text-align: center
       font-size: 18px
     +media($large-screen-up)


### PR DESCRIPTION
# settings

## Before 

<img width="1106" alt="screenshot 2018-11-28 at 15 46 56" src="https://user-images.githubusercontent.com/6270048/49159511-f9caf480-f324-11e8-99dc-30265cbaaa42.png">

## After

<img width="1128" alt="screenshot 2018-11-28 at 15 47 00" src="https://user-images.githubusercontent.com/6270048/49159510-f9caf480-f324-11e8-8ed7-8bfcbfcdce14.png">


# ask HN

## Before
<img width="1186" alt="screenshot 2018-11-28 at 15 47 12" src="https://user-images.githubusercontent.com/6270048/49159502-f5064080-f324-11e8-90ac-764ca868279a.png">

## After

<img width="1130" alt="screenshot 2018-11-28 at 15 47 22" src="https://user-images.githubusercontent.com/6270048/49159503-f59ed700-f324-11e8-883c-acad08a78818.png">
