### PR TITLE
fix(popular): display popular queries if no results are found

### DIFF
--- a/app/assets/javascripts/controllers.js
+++ b/app/assets/javascripts/controllers.js
@@ -578,7 +578,7 @@ angular.module('HNSearch.controllers', ['ngSanitize', 'ngDropdowns', 'pasvaz.bin
 
   $scope.populars = [];
   $http.get('/popular.json').then(function(results) {
-    $scope.populars = results.data;
+    $scope.populars = results.data.searches;
   });
 
   // Handle history

--- a/app/assets/templates/home.html.haml
+++ b/app/assets/templates/home.html.haml
@@ -122,7 +122,7 @@
         %br
         %span{'ng-repeat' => 'p in populars', bindonce: true}
           %span{'ng-show' => '$index !== 0'}>,&nbsp;
-          %a{href: '#', 'ng-click' => 'setQuery($event, p.query)'}>{{ p.query }}
+          %a{href: '#', 'ng-click' => 'setQuery($event, p.search)'}>{{ p.search }}
 
 
   %ul.search-pagination{'ng-if' => 'results && results.nbPages > 1'}

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,11 +1,9 @@
 module Api
   module V1
     class UsersController < BaseController
-
       def show
         render_json_request(:get, "/1/indexes/#{User.index_name}/#{params.delete :username}", params)
       end
-
     end
   end
 end


### PR DESCRIPTION
Fetch popular queries from Analytics API and set cache expiration to midnight (same day precision as analytics API).

![popular](https://user-images.githubusercontent.com/9317857/57698965-29fa1b80-7657-11e9-8c6b-8fd57855c637.gif)