### PR TITLE
add word-break and block display to Story_link

### DIFF
--- a/app/javascript/components/Story/Story.scss
+++ b/app/javascript/components/Story/Story.scss
@@ -63,7 +63,6 @@
     .Story_link {
       color: #828282;
       font-size: 12px;
-      display: inline;
       word-break: break-all;
 
       @media (max-width: 480px){ display: block; }

--- a/app/javascript/components/Story/Story.scss
+++ b/app/javascript/components/Story/Story.scss
@@ -63,7 +63,11 @@
     .Story_link {
       color: #828282;
       font-size: 12px;
-      margin-left: $spacing-base;
+      display: inline;
+      word-break: break-all;
+
+      @media (max-width: 480px){ display: block; }
+      
       &:hover {
         text-decoration: underline;
       }

--- a/app/javascript/components/Story/Story.tsx
+++ b/app/javascript/components/Story/Story.tsx
@@ -108,7 +108,7 @@ const HighlightURL: React.FC<{
   queryID: string;
   indexName: string;
 }> = ({ hit: { url, _highlightResult, objectID }, queryID, indexName }) => {
-  const highlighted = _highlightResult.url.value;
+  const highlighted = `(${_highlightResult.url.value})`;
 
   return (
     <a

--- a/app/javascript/components/Story/Story.tsx
+++ b/app/javascript/components/Story/Story.tsx
@@ -108,7 +108,7 @@ const HighlightURL: React.FC<{
   queryID: string;
   indexName: string;
 }> = ({ hit: { url, _highlightResult, objectID }, queryID, indexName }) => {
-  const highlighted = `(${_highlightResult.url.value})`;
+  const highlighted = _highlightResult.url.value;
 
   return (
     <a


### PR DESCRIPTION
This is an opinionated fix for #160.

Moves the Story link to a new line in mobile responsive views (< 480px width) and allows Story link to break anywhere in its element to prevent overflowing outside of the Story component's width. Because the line break is an appropriate delimiter for the Story link, I've also removed the parenthesis around the URL.