### PR TITLE
fix(theme): add meta color

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -28,6 +28,7 @@
   %meta{name: "twitter:description", content: description}
   %meta{name: "twitter:image:src", content: twitter_url}
   %meta{name: "twitter:domain", content: domain}
+  %meta{name: "color-scheme", content: "light dark"
 
   %meta{property: "st:title", content: title }
   %meta{property: "og:url", content: url }


### PR DESCRIPTION
Fixes Safari error when `null is not an object (evaluating 'document.head.querySelector("meta[name='supported-color-schemes']").content')`