### PR TITLE
MINOR: Remove potentially unnecessary commas

### DIFF
--- a/app/javascript/components/Story/Story.tsx
+++ b/app/javascript/components/Story/Story.tsx
@@ -226,7 +226,7 @@ const Story: React.FC<{
                     {points} points
                   </StoryLink>
                 </span>
-                ,<span className="Story_separator">|</span>
+                <span className="Story_separator">|</span>
               </>
             )}
             <span>
@@ -258,7 +258,7 @@ const Story: React.FC<{
             )}
             {isExperimental && url && (
               <>
-                <span className="Story_separator">|</span>,
+                <span className="Story_separator">|</span>
                 <a href={url} target="_blank" className="Story_link">
                   ({extractDomain(hit.url)})
                 </a>


### PR DESCRIPTION
The PR removes a few commas which seem to be unnecessary because:

- In "Default" style there already are separators ("|")
- In "Experimental" style there's decent spacing between these components

Before:
<img width="478" alt="Screenshot 2020-05-31 at 16 03 27" src="https://user-images.githubusercontent.com/1958718/83353285-26b4f900-a35a-11ea-8a9c-7e71d49ae0c9.png">
<img width="615" alt="Screenshot 2020-05-31 at 16 05 03" src="https://user-images.githubusercontent.com/1958718/83353289-2a488000-a35a-11ea-893c-a6b197dfa7a6.png">

After:
<img width="480" alt="Screenshot 2020-05-31 at 16 11 05" src="https://user-images.githubusercontent.com/1958718/83353290-303e6100-a35a-11ea-8ea0-af3c040db2e5.png">
<img width="590" alt="Screenshot 2020-05-31 at 16 11 24" src="https://user-images.githubusercontent.com/1958718/83353292-33d1e800-a35a-11ea-99f5-8b202f25d41f.png">
