### PR TITLE
Add HN Badges to "Cool Apps" list

### DIFF
--- a/app/javascript/views/CoolApps.tsx
+++ b/app/javascript/views/CoolApps.tsx
@@ -32,6 +32,10 @@ const CoolApps: React.FC<RouteComponentProps> = props => {
           <a href="http://hnrss.org">hnrss.org</a> - Custom, realtime Hacker
           News RSS feeds
         </li>
+        <li>
+          <a href="https://hnbadges.netlify.app/">HN Badges</a> - Game-like
+          badges for your HN profile
+        </li>
       </ul>
       <h3>Chrome Extensions</h3>
       <ul>

--- a/app/javascript/views/CoolApps.tsx
+++ b/app/javascript/views/CoolApps.tsx
@@ -66,6 +66,13 @@ const CoolApps: React.FC<RouteComponentProps> = props => {
       <h3>Firefox Extensions</h3>
       <ul>
         <li>
+          <a href="https://github.com/jstrieb/hackernews-button">
+            Hacker News Discussion Button
+          </a>
+          , a privacy-preserving Firefox extension that uses Bloom filters to
+          link to the Hacker News discussion for the current page.
+        </li>
+        <li>
           <a href="https://addons.mozilla.org/en-US/firefox/addon/hacker-news-reader/">
             Hacker News Reader
           </a>


### PR DESCRIPTION
Add a link to [HN Badges](https://hnbadges.netlify.app/) to the cool apps list.

See: <https://news.ycombinator.com/item?id=28389773>