### PR TITLE
feat: remove virtual replicas from settings

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -58,11 +58,6 @@ class Item < ApplicationRecord
       ranking ['custom']
     end
 
-    # BEG: virtual replica experiment
-    add_replica "vr_Item_#{Rails.env}_sort_date", virtual: true do
-      customRanking ['desc(created_at_i)']
-    end
-    # END: virtual replica experiment
   end
 
   def story_text


### PR DESCRIPTION
The virtual replica is not needed anymore, let's remove it from the app's settings.