### PR TITLE
fix(search): set minProximity to 7 instead of 8

### DIFF
--- a/app/javascript/providers/SearchSettings.ts
+++ b/app/javascript/providers/SearchSettings.ts
@@ -255,7 +255,7 @@ const getRestrictSearchableAttributes = (
 const getMinProximity = (
   type: HNSettings["type"]
 ): SearchSettings["minProximity"] => {
-  return type === "story" ? 8 : 1;
+  return type === "story" ? 7 : 1;
 };
 
 const getSearchSettings = (


### PR DESCRIPTION
Fix proximity not being taken into account when `minProximity` is **8**