### PR TITLE
add `hn.hsblhsn.me` and graphql explorer.

### DIFF
--- a/app/javascript/views/CoolApps.tsx
+++ b/app/javascript/views/CoolApps.tsx
@@ -36,6 +36,14 @@ const CoolApps: React.FC<RouteComponentProps> = props => {
           <a href="https://hnbadges.netlify.app/">HN Badges</a> - Game-like
           badges for your HN profile
         </li>
+        <li>
+          <a href="https://hn.hsblhsn.me/">HackerNews Reader</a> - A 
+          HackerNews Reader focused on content and readability.
+        </li>
+        <li>
+          <a href="https://hn.hsblhsn.me/explorer">GraphQL wrapper for HackerNews</a> 
+          - A GraphQL API wrapper around HackerNews and Algolia's REST API.
+        </li>
       </ul>
       <h3>Chrome Extensions</h3>
       <ul>


### PR DESCRIPTION
Hello,

I created [https://hn.hsblhsn.me](https://hn.hsblhsn.me) a HackerNews reader app focused on content and readability.

I also provide a GraphQL endpoint for HackerNews API and algolia's search API at [https://hn.hsblhsn.me/explorer](https://hn.hsblhsn.me/explorer).

In this PR, I have added them. Please Have a look!


Thank you! :heart: