### PR TITLE
Add underline to current page button

### DIFF
--- a/app/javascript/components/Pagination/Pagination.scss
+++ b/app/javascript/components/Pagination/Pagination.scss
@@ -32,6 +32,7 @@
       button {
         color: $orange;
         border: 1px solid $orange;
+        text-decoration: underline;
       }
     }
   }


### PR DESCRIPTION
Whenever I'm browsing the site during nighttime, my phone has a night mode which makes everything on the screen gray-scale.

In this mode it can be quite hard to see which is the current page as the orange border nearly matches the other gray borders. 

This pull request adds an underline to the current page number as an additional visual indicator to mitigate this issue. 

(I haven't actually looked at the result since I'm on my phone, so if you find some other alternative which looks nicer I'm all for it!)